### PR TITLE
Consistent date selection

### DIFF
--- a/src/paraTimeline.ts
+++ b/src/paraTimeline.ts
@@ -694,55 +694,55 @@ export class paraTimeline implements powerbiVisualsApi.extensibility.visual.IVis
     public setThisMonth(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear(), month = today.getMonth();
         let firstDay = new Date(Math.max(new Date(year, month, 1).getTime(), this.datePeriod.startDate.getTime()));
-        let lastDay = new Date(Math.min(new Date(year, month + 1, 1).getTime(), this.datePeriod.endDate.getTime()));
+        let lastDay = new Date(Math.min(new Date(year, month + 1, 1).getTime(), this.getNextMs(this.datePeriod.endDate).getTime()));
         this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
-        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
-        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
+        startDatePicker.property("value", this.getDateInDefaultFormat(firstDay));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousMs(lastDay)));
     }
 
     public setThisYear(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear(), month = today.getMonth();
-        let firstDay = new Date(Math.max(new Date(year, 1, 1).getTime(), this.datePeriod.startDate.getTime()));
-        let lastDay = new Date(Math.min(new Date(year + 1, 1, 1).getTime(), this.datePeriod.endDate.getTime()));
+        let firstDay = new Date(Math.max(new Date(year, 0, 1).getTime(), this.datePeriod.startDate.getTime()));
+        let lastDay = new Date(Math.min(new Date(year + 1, 0, 1).getTime(), this.getNextMs(this.datePeriod.endDate).getTime()));
         this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
-        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
-        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
+        startDatePicker.property("value", this.getDateInDefaultFormat(firstDay));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousMs(lastDay)));
     }
 
     public setLastMonth(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear(), month = today.getMonth() - 1;
         let firstDay = new Date(Math.max(new Date(year, month, 1).getTime(), this.datePeriod.startDate.getTime()));
-        let lastDay = new Date(Math.min(new Date(year, month + 1, 1).getTime(), this.datePeriod.endDate.getTime()));
+        let lastDay = new Date(Math.min(new Date(year, month + 1, 1).getTime(), this.getNextMs(this.datePeriod.endDate).getTime()));
         this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
-        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
-        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
+        startDatePicker.property("value", this.getDateInDefaultFormat(firstDay));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousMs(lastDay)));
     }
 
     public setLastYear(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear() - 1, month = today.getMonth();
-        let firstDay = new Date(Math.max(new Date(year, 1, 1).getTime(), this.datePeriod.startDate.getTime()));
-        let lastDay = new Date(Math.min(new Date(year + 1, 1, 1).getTime(), this.datePeriod.endDate.getTime()));
+        let firstDay = new Date(Math.max(new Date(year, 0, 1).getTime(), this.datePeriod.startDate.getTime()));
+        let lastDay = new Date(Math.min(new Date(year + 1, 0, 1).getTime(), this.getNextMs(this.datePeriod.endDate).getTime()));
         this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
-        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
-        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
+        startDatePicker.property("value", this.getDateInDefaultFormat(firstDay));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousMs(lastDay)));
     }
 
     public setMTD(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear(), month = today.getMonth();
         let firstDay = new Date(Math.max(new Date(year, month, 1).getTime(), this.datePeriod.startDate.getTime()));
-        let lastDay = new Date(Math.min(today.getTime(), this.datePeriod.endDate.getTime()));
+        let lastDay = new Date(Math.min(this.getNextMs(today).getTime(), this.getNextMs(this.datePeriod.endDate).getTime()));
         this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
-        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
-        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
+        startDatePicker.property("value", this.getDateInDefaultFormat(firstDay));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousMs(lastDay)));
     }
 
     public setYTD(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear(), month = today.getMonth();
-        let firstDay = new Date(Math.max(new Date(year, 0, 0).getTime(), this.datePeriod.startDate.getTime()));
-        let lastDay = new Date(Math.min(today.getTime(), this.datePeriod.endDate.getTime()));
+        let firstDay = new Date(Math.max(new Date(year, 0, 1).getTime(), this.datePeriod.startDate.getTime()));
+        let lastDay = new Date(Math.min(this.getNextMs(today).getTime(), this.getNextMs(this.datePeriod.endDate).getTime()));
         this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
-        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
-        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
+        startDatePicker.property("value", this.getDateInDefaultFormat(firstDay));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousMs(lastDay)));
     }
 
     public clearUserSelection(): void {
@@ -752,7 +752,7 @@ export class paraTimeline implements powerbiVisualsApi.extensibility.visual.IVis
 
         this.clearSelection(this.timelineData.filterColumnTarget);
         this.toggleForceSelectionOptions();
-        this.applyDatePeriod(this.datePeriod.startDate, this.datePeriod.endDate, this.timelineData.filterColumnTarget);
+        this.applyDatePeriod(this.datePeriod.startDate, this.getNextMs(this.datePeriod.endDate), this.timelineData.filterColumnTarget);
     }
 
     public doesPeriodSlicerRectPositionNeedToUpdate(granularity: GranularityType): boolean {
@@ -786,18 +786,12 @@ export class paraTimeline implements powerbiVisualsApi.extensibility.visual.IVis
         );
     }
 
-    public getPreviousHour(date) {
-        const previous = new Date(date.getTime());
-        previous.setHours(date.getHours() - 1);
-      
-        return previous;
+    public getPreviousMs(date) {
+        return new Date(date.getTime() - 1);
     }
 
-    public getNextHour(date) {
-        const previous = new Date(date.getTime());
-        previous.setHours(date.getHours() + 12);
-      
-        return previous;
+    public getNextMs(date) {
+        return new Date(date.getTime() + 1);
     }
 
     public getNextDay(date) {
@@ -926,8 +920,8 @@ export class paraTimeline implements powerbiVisualsApi.extensibility.visual.IVis
 
         //Set the value of the date pickers to be that closest and further date available
         if (filterDatePeriod && filterDatePeriod["startDate"] && filterDatePeriod["endDate"]) {
-            this.endDatePicker.node().value = this.getDateInDefaultFormat(this.getPreviousHour(filterDatePeriod["endDate"]));
-            this.startDatePicker.node().value = this.getDateInDefaultFormat(this.getNextHour(filterDatePeriod["startDate"]));
+            this.endDatePicker.node().value = this.getDateInDefaultFormat(this.getPreviousMs(filterDatePeriod["endDate"]));
+            this.startDatePicker.node().value = this.getDateInDefaultFormat(filterDatePeriod["startDate"]);
             
             // this.startDatePicker.property("value", this.dateToString(filterDatePeriod["startDate"]));
             // this.endDatePicker.property("value", this.dateToString(filterDatePeriod["endDate"]));
@@ -1225,6 +1219,7 @@ export class paraTimeline implements powerbiVisualsApi.extensibility.visual.IVis
         endDate: Date,
         target: IFilterColumnTarget,
     ): void {
+        console.log(`applyDatePeriod(${startDate}, ${endDate})`);
         this.host.applyJsonFilter(
             this.createFilter(startDate, endDate, target),
             paraTimeline.filterObjectProperty.objectName,

--- a/src/paraTimeline.ts
+++ b/src/paraTimeline.ts
@@ -693,66 +693,56 @@ export class paraTimeline implements powerbiVisualsApi.extensibility.visual.IVis
 
     public setThisMonth(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear(), month = today.getMonth();
-        let startDate = Utils.CTZ(startDatePicker.node().value);
-        let endDate = Utils.CTZ(endDatePicker.node().value, false);
-        let firstDay = new Date(Math.max(new Date(year, month, 0).getTime(), this.datePeriod.startDate.getTime()));
-        let lastDay = new Date(Math.min(new Date(year, month + 1, 0).getTime(), this.datePeriod.endDate.getTime()));
-        startDatePicker.property("value", this.dateToString(firstDay));
-        endDatePicker.property("value", this.dateToString(lastDay));
-        this.updateDate(this.startDatePicker, this.endDatePicker);
+        let firstDay = new Date(Math.max(new Date(year, month, 1).getTime(), this.datePeriod.startDate.getTime()));
+        let lastDay = new Date(Math.min(new Date(year, month + 1, 1).getTime(), this.datePeriod.endDate.getTime()));
+        this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
+        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
     }
 
     public setThisYear(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear(), month = today.getMonth();
-        let startDate = Utils.CTZ(startDatePicker.node().value);
-        let endDate = Utils.CTZ(endDatePicker.node().value, false);
-        let firstDay = new Date(Math.max(new Date(year, 0, 0).getTime(), this.datePeriod.startDate.getTime()));
-        let lastDay = new Date(Math.min(new Date(year, 11, 31).getTime(), this.datePeriod.endDate.getTime()));
-        startDatePicker.property("value", this.dateToString(firstDay));
-        endDatePicker.property("value", this.dateToString(lastDay));
-        this.updateDate(this.startDatePicker, this.endDatePicker);
+        let firstDay = new Date(Math.max(new Date(year, 1, 1).getTime(), this.datePeriod.startDate.getTime()));
+        let lastDay = new Date(Math.min(new Date(year + 1, 1, 1).getTime(), this.datePeriod.endDate.getTime()));
+        this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
+        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
     }
 
     public setLastMonth(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear(), month = today.getMonth() - 1;
-        let startDate = Utils.CTZ(startDatePicker.node().value);
-        let endDate = Utils.CTZ(endDatePicker.node().value, false);
-        let firstDay = new Date(Math.max(new Date(year, month, 0).getTime(), this.datePeriod.startDate.getTime()));
-        let lastDay = new Date(Math.min(new Date(year, month + 1, 0).getTime(), this.datePeriod.endDate.getTime()));
-        startDatePicker.property("value", this.dateToString(firstDay));
-        endDatePicker.property("value", this.dateToString(lastDay));
-        this.updateDate(this.startDatePicker, this.endDatePicker);
+        let firstDay = new Date(Math.max(new Date(year, month, 1).getTime(), this.datePeriod.startDate.getTime()));
+        let lastDay = new Date(Math.min(new Date(year, month + 1, 1).getTime(), this.datePeriod.endDate.getTime()));
+        this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
+        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
     }
 
     public setLastYear(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear() - 1, month = today.getMonth();
-        let startDate = Utils.CTZ(startDatePicker.node().value);
-        let endDate = Utils.CTZ(endDatePicker.node().value, false);
-        let firstDay = new Date(Math.max(new Date(year, 0, 0).getTime(), this.datePeriod.startDate.getTime()));
-        let lastDay = new Date(Math.min(new Date(year, 11, 31).getTime(), this.datePeriod.endDate.getTime()));
-        startDatePicker.property("value", this.dateToString(firstDay));
-        endDatePicker.property("value", this.dateToString(lastDay));
-        this.updateDate(this.startDatePicker, this.endDatePicker);
+        let firstDay = new Date(Math.max(new Date(year, 1, 1).getTime(), this.datePeriod.startDate.getTime()));
+        let lastDay = new Date(Math.min(new Date(year + 1, 1, 1).getTime(), this.datePeriod.endDate.getTime()));
+        this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
+        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
     }
 
     public setMTD(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear(), month = today.getMonth();
-        let startDate = Utils.CTZ(startDatePicker.node().value);
-        let endDate = Utils.CTZ(endDatePicker.node().value, false);
-        let firstDay = new Date(Math.max(new Date(year, month, 0).getTime(), this.datePeriod.startDate.getTime()));
+        let firstDay = new Date(Math.max(new Date(year, month, 1).getTime(), this.datePeriod.startDate.getTime()));
         let lastDay = new Date(Math.min(today.getTime(), this.datePeriod.endDate.getTime()));
-        startDatePicker.property("value", this.dateToString(firstDay));
-        endDatePicker.property("value", this.dateToString(lastDay));
+        this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
+        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
     }
 
     public setYTD(startDatePicker, endDatePicker) {
         let today = new Date(), year = today.getFullYear(), month = today.getMonth();
-        let startDate = Utils.CTZ(startDatePicker.node().value);
-        let endDate = Utils.CTZ(endDatePicker.node().value, false);
         let firstDay = new Date(Math.max(new Date(year, 0, 0).getTime(), this.datePeriod.startDate.getTime()));
         let lastDay = new Date(Math.min(today.getTime(), this.datePeriod.endDate.getTime()));
-        startDatePicker.property("value", this.dateToString(firstDay));
-        endDatePicker.property("value", this.dateToString(lastDay));
+        this.applyDatePeriod(firstDay, lastDay, this.timelineData.filterColumnTarget);
+        startDatePicker.property("value", this.getDateInDefaultFormat(this.getNextHour(firstDay)));
+        endDatePicker.property("value", this.getDateInDefaultFormat(this.getPreviousHour(lastDay)));
     }
 
     public clearUserSelection(): void {
@@ -790,8 +780,8 @@ export class paraTimeline implements powerbiVisualsApi.extensibility.visual.IVis
 
     private updateDate(startDatePicker, endDatePicker) {
         this.applyDatePeriod(
-            Utils.CTZ(startDatePicker.node().value),
-            Utils.CTZ(endDatePicker.node().value, false),
+            new Date(startDatePicker.node().value),
+            this.getNextDay(new Date(endDatePicker.node().value)),
             this.timelineData.filterColumnTarget,
         );
     }
@@ -806,6 +796,13 @@ export class paraTimeline implements powerbiVisualsApi.extensibility.visual.IVis
     public getNextHour(date) {
         const previous = new Date(date.getTime());
         previous.setHours(date.getHours() + 12);
+      
+        return previous;
+    }
+
+    public getNextDay(date) {
+        const previous = new Date(date.getTime());
+        previous.setDate(date.getDate() + 1);
       
         return previous;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -125,13 +125,6 @@ export class Utils {
             date.getDate());
     }
 
-    public static CTZ(date, se=true) {
-        let dt = new Date(date);
-        if (se) return new Date(dt.setHours(dt.getHours() + 7));
-        return new Date(dt.setHours(dt.getHours() + 7));
-        return new Date((typeof date === "string" ? new Date(date) : date).toLocaleString("en-US", {timeZone: "America/New_York"}));
-    }
-
     public static GETDATEPRIOD(values: any[]): ITimelineDatePeriodBase {
         let startDate: Date;
         let endDate: Date;


### PR DESCRIPTION
This makes selecting in the cells, clicking a "This..." or "Last..." button, or entering dates directly all behave consistently in selecting a date range consisting of complete days, from the start to the end displayed in the date pickers inclusive of the end day.

Previously, clicking a month in the cells set the filter to >= the first of the month at 00:00 and < the first of the following month at 00:00 and set the date pickers to show from the first of the month to the last of the month. However, clicking on "This month" set the filter to >= the day before the first of the month at 07:00 and < the last day of the month at 07:00, and set the date pickers to show from the first of the month to the last of the month. Directly entering dates selected from 07:00 on the start day to 07:00 on the end day.